### PR TITLE
Option to leave off empty array braces.

### DIFF
--- a/multidimensional_urlencode/tests/test_urlencode.py
+++ b/multidimensional_urlencode/tests/test_urlencode.py
@@ -47,4 +47,11 @@ def test_no_array_braces():
     """Verify that array braces can be left off."""
     d = {'a': {"b": [1, 2, 3]}}
     expected = "a[b]=1&a[b]=2&a[b]=3"
-    assert unquote(urlencode(d)) == expected
+    assert unquote(urlencode(d, array_braces=False)) == expected
+
+
+def test_encode_list_key():
+    """Verify that list indexes are explicitly added."""
+    d = {'a': {"b": [1, 2, 3]}}
+    expected = "a[b][0]=1&a[b][1]=2&a[b][2]=3"
+    assert unquote(urlencode(d, encode_list_key=True)) == expected

--- a/multidimensional_urlencode/tests/test_urlencode.py
+++ b/multidimensional_urlencode/tests/test_urlencode.py
@@ -41,3 +41,9 @@ def test_with_non_dict():
     """Verify that we raise an exception when passing a non-dict."""
     with pytest.raises(TypeError):
         urlencode("e")
+
+def test_no_array_braces():
+    """Verify that array braces can be left off."""
+    d = {'a': {"b": [1, 2, 3]}}
+    expected = "a[b]=1&a[b]=2&a[b]=3"
+    assert unquote(urlencode(d)) == expected

--- a/multidimensional_urlencode/tests/test_urlencode.py
+++ b/multidimensional_urlencode/tests/test_urlencode.py
@@ -42,6 +42,7 @@ def test_with_non_dict():
     with pytest.raises(TypeError):
         urlencode("e")
 
+
 def test_no_array_braces():
     """Verify that array braces can be left off."""
     d = {'a': {"b": [1, 2, 3]}}

--- a/multidimensional_urlencode/urlencoder.py
+++ b/multidimensional_urlencode/urlencoder.py
@@ -61,7 +61,16 @@ def parametrize(params):
 
 
 def urlencode(params, encode_list_key=False, array_braces=True):
-    """Urlencode a multidimensional dict."""
+    """Urlencode a multidimensional dict.
+
+    >>> urlencode({'a': {"b": [1, 2, 3]}})
+    'a[b][]=1&a[b][]=2&a[b][]=3'
+    >>> urlencode({'a': {"b": [1, 2, 3]}}, array_braces=False)
+    'a[b]=1&a[b]=2&a[b]=3'
+    >>> urlencode({'a': {"b": [1, 2, 3]}}, encode_list_key=True)
+    'a[b][0]=1&a[b][1]=2&a[b][2]=3'
+
+    """
 
     # Not doing duck typing here. Will make debugging easier.
     if not isinstance(params, dict):

--- a/multidimensional_urlencode/urlencoder.py
+++ b/multidimensional_urlencode/urlencoder.py
@@ -63,11 +63,16 @@ def parametrize(params):
 def urlencode(params, encode_list_key=False, array_braces=True):
     """Urlencode a multidimensional dict.
 
-    >>> urlencode({'a': {"b": [1, 2, 3]}})
+    >>> try:
+    ...     from urllib.parse import quote, unquote
+    ... except ImportError:
+    ...     from urllib import quote, unquote
+    ...
+    >>> unquote(urlencode({'a': {"b": [1, 2, 3]}}))
     'a[b][]=1&a[b][]=2&a[b][]=3'
-    >>> urlencode({'a': {"b": [1, 2, 3]}}, array_braces=False)
+    >>> unquote(urlencode({'a': {"b": [1, 2, 3]}}, array_braces=False))
     'a[b]=1&a[b]=2&a[b]=3'
-    >>> urlencode({'a': {"b": [1, 2, 3]}}, encode_list_key=True)
+    >>> unquote(urlencode({'a': {"b": [1, 2, 3]}}, encode_list_key=True))
     'a[b][0]=1&a[b][1]=2&a[b][2]=3'
 
     """

--- a/multidimensional_urlencode/urlencoder.py
+++ b/multidimensional_urlencode/urlencoder.py
@@ -54,7 +54,7 @@ def parametrize(params):
     return returned
 
 
-def urlencode(params):
+def urlencode(params, array_braces=True):
     """Urlencode a multidimensional dict."""
 
     # Not doing duck typing here. Will make debugging easier.
@@ -68,7 +68,7 @@ def urlencode(params):
         value = param.pop()
 
         name = parametrize(param)
-        if isinstance(value, (list, tuple)):
+        if isinstance(value, (list, tuple)) and array_braces:
             name += "[]"
 
         url_params[name] = value


### PR DESCRIPTION
The combination of [querystring_parser](https://github.com/bernii/querystring-parser) and Django will not correctly parse the params generated by this library unless you leave off the empty braces `[]`. This patch adds an option to do so.